### PR TITLE
feat: actualizar referencias a magic-15-07-2025-dev

### DIFF
--- a/setup-ngrok-autostart.sh
+++ b/setup-ngrok-autostart.sh
@@ -13,21 +13,21 @@ cat > "$AUTOSTART_DIR/ngrok-jenkins.desktop" << EOF
 Type=Application
 Name=ngrok Jenkins Tunnel
 Comment=Inicia túnel ngrok para Jenkins automáticamente
-Exec=$HOME/Magic-14aug-DEV/start-ngrok.sh
+Exec=$HOME/magic-15-07-2025-dev/start-ngrok.sh
 Terminal=false
 X-GNOME-Autostart-enabled=true
 Hidden=false
 EOF
 
 # Hacer ejecutable el script
-chmod +x "$HOME/Magic-14aug-DEV/start-ngrok.sh"
+chmod +x "$HOME/magic-15-07-2025-dev/start-ngrok.sh"
 
 # Agregar alias al .bashrc
 BASH_RC="$HOME/.bashrc"
 if ! grep -q "ngrok-jenkins" "$BASH_RC"; then
     echo "" >> "$BASH_RC"
     echo "# ngrok Jenkins Tunnel" >> "$BASH_RC"
-    echo "alias ngrok-jenkins='$HOME/Magic-14aug-DEV/start-ngrok.sh'" >> "$BASH_RC"
+    echo "alias ngrok-jenkins='$HOME/magic-15-07-2025-dev/start-ngrok.sh'" >> "$BASH_RC"
     echo "alias ngrok-status='curl -s http://localhost:4040/api/tunnels | jq .'" >> "$BASH_RC"
     echo "alias ngrok-stop='pkill -f \"ngrok http 8081\"'" >> "$BASH_RC"
 fi
@@ -46,7 +46,7 @@ echo "   • Al abrir terminal (alias)"
 echo ""
 echo "📁 Archivos creados:"
 echo "   • $AUTOSTART_DIR/ngrok-jenkins.desktop"
-echo "   • $HOME/Magic-14aug-DEV/start-ngrok.sh"
+echo "   • $HOME/magic-15-07-2025-dev/start-ngrok.sh"
 echo "   • Aliases en $BASH_RC"
 echo ""
 echo "💡 Para probar ahora:"

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,7 @@ const myAccountRoute = () => {
     <div class="navbar-container">
       <div class="brand">
         <img alt="Vue logo" class="logo" src="@/assets/logo.svg" width="50" height="50" />
-        <h1>Magic-14aug-DEV</h1>
+        <h1>magic-15-07-2025-dev</h1>
       </div>
 
       <nav class="nav-links">


### PR DESCRIPTION
- Cambiado título del header en App.vue de 'Magic-14aug-DEV' a 'magic-15-07-2025-dev'
- Actualizado setup-ngrok-autostart.sh para usar magic-15-07-2025-dev